### PR TITLE
Add pre-commit to CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,10 @@ jobs:
         with:
           xcode-version: latest-stable
 
+      - name: Pre-commit checks
+        working-directory: ${{github.workspace}}
+        run: pre-commit run --all-files
+
       - name: Create build directory
         run: cmake -E make_directory ${{github.workspace}}/build-${{matrix.build_type}}
 
@@ -100,7 +104,23 @@ jobs:
         run: |
           cmake ${{github.workspace}} -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -Wno-deprecated -G Ninja
 
-      - name: Build
+      - if: runner.os == 'Windows'
+        name: Build (Windows)
         working-directory: ${{github.workspace}}/build-${{matrix.build_type}}
         run: |
-          cmake --build . --config ${{matrix.build_type}}
+          $threads = (Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors
+          cmake --build . --config ${{matrix.build_type}} --parallel $threads
+
+      - if: runner.os == 'macOS'
+        name: Build (OSX)
+        working-directory: ${{github.workspace}}/build-${{matrix.build_type}}
+        run: |
+          threads=`sysctl -n hw.logicalcpu`
+          cmake --build . --config ${{matrix.build_type}} --parallel $threads
+
+      - if: runner.os == 'Linux'
+        name: Build (Linux)
+        working-directory: ${{github.workspace}}/build-${{matrix.build_type}}
+        run: |
+          threads=`nproc`
+          cmake --build . --config ${{matrix.build_type}} --parallel $threads


### PR DESCRIPTION
- Pre-commit runs as part of the CI configuration.
- Update the build step to make sure it leverages runner parallelism.